### PR TITLE
Feat/serial connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pip install -r requirements.txt
 ```
 
 ## Usage
+### Using TCP connection, e.g. Compute Box
 
 1. Connect the cable between Compute Box and Tool Changer.
 2. Connect an ethernet cable between Compute Box and your computer.
@@ -28,9 +29,23 @@ python src/demo.py --ip 192.168.1.1 --port 502
 
 <img src="img/vgc10_2x.gif" height="200">  
 
+### Using serial connection, e.g. UR Robot with RS-485 daemon forwarded to local machine
+
+1. Make sure the RS-485 daemon is running on your robot controller and it is available on port `54321`, details: [Here](https://github.com/UniversalRobots/Universal_Robots_ToolComm_Forwarder_URCap)
+2. Forward that serial connection between to your computer using `socat`:
+```bash
+export UR_IP=192.168.4.2
+export LOCAL_DEVICE_NAME=/tmp/ttyUR
+socat pty,link=${LOCAL_DEVICE_NAME},raw,ignoreeof,waitslave tcp:${ROBOT_IP}:54321
+```
+3. Execute a demo script as below  
+```bash
+python src/demo.py --device ${LOCAL_DEVICE_NAME}
+```
 ## Author / Contributor
 
 [Takuya Kiyokawa](https://takuya-ki.github.io/)
+[Felix Warmuth](https://github.com/fwarmuth)
 
 ## License
 

--- a/src/demo.py
+++ b/src/demo.py
@@ -9,17 +9,21 @@ def get_options():
     """Returns user-specific options."""
     parser = argparse.ArgumentParser(description='Set options.')
     parser.add_argument(
-        '--ip', dest='ip', type=str, default="192.168.1.1",
+        '--ip', dest='ip', type=str, default=None,
         help='set ip address')
     parser.add_argument(
         '--port', dest='port', type=str, default="502",
         help='set port number')
+    parser.add_argument(
+        '--device', dest="device", type=str,  default=None,
+        help='set device path'
+    )
     return parser.parse_args()
 
 
 def run_demo():
     """Runs pump on/off demonstration once."""
-    vg = VG(toolchanger_ip, toolchanger_port)
+    vg = VG(ip=toolchanger_ip, port=toolchanger_port, device=args.device)
 
     vg.vacuum_on(sleep_sec=5.0)
     vg.release_vacuum()


### PR DESCRIPTION
Hey,
this feature adds a serial device connection method.
- New argument `--device` passing in the device path.
- Selects based on the given arguments which connection method to be used.
- Helps non Compute Box users connecting to the gripper. 

Tested with UR10e as connection hop.

If anything is wrong, I am willing to contribute!
Regards
